### PR TITLE
specify list context for URI::Template 0.21

### DIFF
--- a/lib/Catmandu/Importer/getJSON.pm
+++ b/lib/Catmandu/Importer/getJSON.pm
@@ -42,7 +42,7 @@ sub _trigger_url {
     }
 
     if ($url->isa('URI::Template')) {
-        unless ($url->variables) {
+        unless ( my @variables = $url->variables ) {
             $url = URI->new("$url");
         }
     }


### PR DESCRIPTION
URI::Template has been changed 'variables' method on 0.21.

diffs are:

0.20:

    return keys %{ $_[ 0 ]->{ _vars } };

0.21:

    return sort {$_[ 0 ]->{ _vars }->{ $a } <=> $_[ 0 ]->{ _vars }->{ $b } } keys %{ $_[ 0 ]->{ _vars } };

`keys` returns a count of list in the scalar context, but `sort` returns the **undef** in the scalar context. via `perldoc -f sort`

relate: https://github.com/nichtich/Catmandu-Importer-getJSON/issues/10