### PR TITLE
fix md5_hex warning (argument must be plain string, not object)

### DIFF
--- a/lib/Catmandu/Importer/getJSON.pm
+++ b/lib/Catmandu/Importer/getJSON.pm
@@ -89,7 +89,7 @@ $CACHE = Importer::getJSON::MemoryCache->new;
 
     sub file {
         my ( $self, $url ) = @_;
-        $self->{dir} . '/' . md5_hex($url) . '.json';
+        $self->{dir} . '/' . md5_hex($url->as_string) . '.json';
     }
 
     sub get {


### PR DESCRIPTION
resolves issue #19 