### PR TITLE
fix failing import test

### DIFF
--- a/t/10_import.t
+++ b/t/10_import.t
@@ -57,8 +57,12 @@ my $importer = Catmandu::Importer::getJSON->new(
     client => MockFurl::new( content => '[{"n":1},{"n":2}]' ),
     from   => 'http://example.org',
 );
-is_deeply $importer->first, {n => 1}, 'array response 1/2';
-is_deeply $importer->rest->first, { n => 2}, 'array response 2/2';
+
+{
+    my $res = $importer->to_array;
+    is_deeply $res->[0], {n => 1}, 'array response 1/2';
+    is_deeply $res->[1], { n => 2}, 'array response 2/2';
+}
 
 {
     my $warning; local $SIG{__WARN__} = sub { $warning = shift };


### PR DESCRIPTION
test failed because an importer can only be called once and ambiguous is_deeply argument syntax

```
Creating new 'Build' script for 'Catmandu-Importer-getJSON' version '0.51'
cp lib/Catmandu/Fix/get_json.pm blib/lib/Catmandu/Fix/get_json.pm
cp lib/Catmandu/Importer/getJSON.pm blib/lib/Catmandu/Importer/getJSON.pm
t/00_compile.t ......... ok   
t/10_import.t .......... 1/? 
#   Failed test at t/10_import.t line 61.
#     Structures begin differing at:
#          $got = HASH(0x247e498)
#     $expected = 'array response 2/2'
# Looks like you failed 1 test of 12.
t/10_import.t .......... Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/12 subtests 

```